### PR TITLE
fix: correct protocol between ALB and app

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -56,7 +56,7 @@ resource "aws_lb_listener" "alb" {
 resource "aws_lb_target_group" "alb" {
   name_prefix = "gatus"
   port        = 8080
-  protocol    = var.alb_listener_config.protocol
+  protocol    = "HTTP"
   vpc_id      = var.vpc_id
   target_type = "ip"
 


### PR DESCRIPTION
ALB listener config protocol should only be for the listener. The traffic between the ALB and app should be HTTP. This resolves the 503 errors encountered when setting listener protocol to HTTPS.